### PR TITLE
Fix AttributeError in example_extension.py

### DIFF
--- a/examples/example_extension.py
+++ b/examples/example_extension.py
@@ -5,7 +5,7 @@ ext.set_activity_bar(
     vscode.ext.ActivityBar(
         id=ext.name, title=ext.display_name, icon="media/python.svg"
     ),
-    vscode.ext.StaticWebview(f"{ext.name}.activity", html='<h1>Welcome"!</h1>'),
+    vscode.webview.StaticWebview(f"{ext.name}.activity", html='<h1>Welcome"!</h1>'),
 )
 
 


### PR DESCRIPTION
Makes the example `example_extension.py` runnable.

Looks like the `StaticWebview` class was moved to `vscode/vebviews` rather than `vscode/ext`.