### PR TITLE
Added ms-python environment integration

### DIFF
--- a/vscode/compiler.py
+++ b/vscode/compiler.py
@@ -7,10 +7,7 @@ from .extension import Extension
 from .themes import ColorTheme
 
 
-__all__ = (
-    'build',
-    'build_theme'
-)
+__all__ = ("build", "build_theme")
 
 
 def create_package(data: dict, config: dict) -> dict:
@@ -114,10 +111,7 @@ def build_js(name, events, commands, activity_bar_config=None):
             f"let {command.name} = vscode.commands.registerCommand('{command.extension(name)}',"
             + "async function () {\n"
         )
-        pyvar = "python" if os.name == "nt" else "python3"
-        code_on_activate += (
-            f'let funcName = "{command.func_name}"; let pyVar = "{pyvar}";'
-        )
+        code_on_activate += f'let funcName = "{command.func_name}"; let pyVar = pyEnv;'
         code_on_activate += """
         let py = spawn(pyVar, [pythonPath, funcName]);
 

--- a/vscode/data.py
+++ b/vscode/data.py
@@ -5,7 +5,13 @@ const path = require("path");
 const pythonPath = path.join(__dirname, "extension.py");
 const requirements = path.join(__dirname, "../requirements.txt");
 const extension = vscode.extensions.getExtension("ms-python.python");
-const pyEnv = extension.exports.settings.getExecutionDetails().execCommand[0];
+
+let pyEnv;
+if (!extension || !extension.isActive) {
+  pyEnv = "python3";
+} else {
+  pyEnv = extension.exports.settings.getExecutionDetails().execCommand[0];
+}
 
 spawn(pyEnv, ["-m", "pip", "install", "-r", requirements]);
 

--- a/vscode/data.py
+++ b/vscode/data.py
@@ -4,13 +4,10 @@ const spawn = require("child_process").spawn;
 const path = require("path");
 const pythonPath = path.join(__dirname, "extension.py");
 const requirements = path.join(__dirname, "../requirements.txt");
-const osvar = process.platform;
+const extension = vscode.extensions.getExtension("ms-python.python");
+const pyEnv = extension.exports.settings.getExecutionDetails().execCommand[0];
 
-if (osvar == "win32") {
-  spawn("python", ["-m", "pip", "install", "-r", requirements]);
-} else {
-  spawn("python3", ["-m", "pip3", "install", "-r", requirements]);
-}
+spawn(pyEnv, ["-m", "pip", "install", "-r", requirements]);
 
 function executeCommands(pythonProcess, data, globalStorage) {
   let ogdata = data.toString();

--- a/vscode/main.js
+++ b/vscode/main.js
@@ -5,7 +5,13 @@ const path = require("path");
 const pythonPath = path.join(__dirname, "extension.py");
 const requirements = path.join(__dirname, "../requirements.txt");
 const extension = vscode.extensions.getExtension("ms-python.python");
-const pyEnv = extension.exports.settings.getExecutionDetails().execCommand[0];
+
+let pyEnv;
+if (!extension || !extension.isActive) {
+  pyEnv = "python3";
+} else {
+  pyEnv = extension.exports.settings.getExecutionDetails().execCommand[0];
+}
 
 spawn(pyEnv, ["-m", "pip", "install", "-r", requirements]);
 

--- a/vscode/main.js
+++ b/vscode/main.js
@@ -4,13 +4,10 @@ const spawn = require("child_process").spawn;
 const path = require("path");
 const pythonPath = path.join(__dirname, "extension.py");
 const requirements = path.join(__dirname, "../requirements.txt");
-const osvar = process.platform;
+const extension = vscode.extensions.getExtension("ms-python.python");
+const pyEnv = extension.exports.settings.getExecutionDetails().execCommand[0];
 
-if (osvar == "win32") {
-  spawn("python", ["-m", "pip", "install", "-r", requirements]);
-} else {
-  spawn("python3", ["-m", "pip3", "install", "-r", requirements]);
-}
+spawn(pyEnv, ["-m", "pip", "install", "-r", requirements]);
 
 function executeCommands(pythonProcess, data, globalStorage) {
   let ogdata = data.toString();


### PR DESCRIPTION
**Summary**
This PR reworks how Python is called in `extension.js` so that Python is called from the active Python environment in CS code.

**Background**
In it's existing form, Python is directly immediately after imports based on architecture, and then in extensions code is generated based on architecture type in `compiler.py`. This means Python is called based on the system environment, rather than the active environment in VS Code.

**What is Changed**
This PR grabs the path to the current Python environment from the official Python extension, `ms-python`. It then replaces the current way that Python is being called with the Python binary associated with the active environment.

**Potential Pitfalls**
This may be a bad approach for situations where someone designs a fairly code agnostic extension, such as a color theme. For example, if someone installs a color theme designed in `vscode-ext` but they code in a language other than Python, it's unclear if the active Python environment exists or is even a good option. There may also be an issue if someone doesn't have the official Python extension installed. These should be fixable with a few lines of code, but I think feedback/discussion on this might be useful before additional work is performed.

**Notes**
I only deleted 6 lines of code and added 3 lines of code at the top of `data.py`, but git decided to rewrite the whole file ¯\_(ツ)_/¯

I was going to try and merge with your `rewrite` branch, but that looks like it's still pretty premature.

Related to #25