### PR TITLE
Partial Implementation of Pydantic

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,4 @@
 mkdocs-material
 mkdocstrings
+pydantic
+websockets

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 websockets
+pydantic

--- a/vscode/extcode.py
+++ b/vscode/extcode.py
@@ -32,7 +32,10 @@ function activate(context) {
     );
   }
 
-  pyVar = path.join(venvPath, process.platform == "win32" ? "Scripts/python.exe": "bin/python");
+  pyVar = path.join(
+    venvPath,
+    process.platform == "win32" ? "Scripts/python.exe" : "bin/python"
+  );
   let py = spawn(pyVar, [pythonExtensionPath, "test"]);
 
   py.stdout.on("data", (data) => {

--- a/vscode/extension.py
+++ b/vscode/extension.py
@@ -1,13 +1,17 @@
 import sys
 import asyncio
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, List, Coroutine
 
+import vscode
 from vscode.context import Context
 from vscode.wsclient import WSClient
-from vscode.compiler import build
 from vscode.utils import *
 
-__all__ = ("Extension", "Command")
+from pydantic import BaseModel, Field, validator, constr
+
+__all__ = ("Extension", "Command", "Launch")
+
+SEMVER_REGEX = "^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
 
 
 class Extension:
@@ -42,24 +46,32 @@ class Extension:
         Register a command.
         This is usually not called, instead the command() shortcut decorators should be used instead.
         Args:
-            func: 
+            func:
                 The function to register as a command.
-            name: 
+            name:
                 The internal name of the command.
-            title: 
+            title:
                 The title of the command. This is shown in the command palette.
-            category: 
+            category:
                 The category that this command belongs to.
                 Default categories set by Extensions will be overriden if this is not None.
                 False should be passed in order to override a default category.
-            keybind: 
+            keybind:
                 The keybind for this command.
-            when: 
+            when:
                 A condition for when keybinds should be functional.
         """
         name = func.__name__ if name is None else name
         category = self.default_category if category is None else category
-        command = Command(name, func, self, title, category, keybind, when)
+        command = Command(
+            name=name,
+            func=func,
+            ext=self,
+            title=title,
+            category=category,
+            keybind=keybind,
+            when=when,
+        )
         if keybind:
             self.register_keybind(command)
         self.commands.append(command)
@@ -75,17 +87,17 @@ class Extension:
         """
         A decorator for registering commands.
         Args:
-            name: 
+            name:
                 The internal name of the command.
-            title: 
+            title:
                 The title of the command. This is shown in the command palette.
-            category: 
+            category:
                 The category that this command belongs to.
                 Default categories set by Extensions will be overriden if this is not None.
                 False should be passed in order to override a default category.
-            keybind: 
+            keybind:
                 The keybind for this command.
-            when: 
+            when:
                 A condition for when keybinds should be functional.
         """
 
@@ -116,19 +128,19 @@ class Extension:
         if len(sys.argv) > 1:
             self.ws.run_webserver()
         else:
-            build(self)
+            vscode.compiler.build(self)
 
     async def parse_ws_data(self, data: dict):
-        if data["type"] == 1: # Command 
+        if data["type"] == 1:  # Command
             name = data.get("name")
-            if any(name == (cmd:=i).name for i in self.commands):
+            if any(name == (cmd := i).name for i in self.commands):
                 ctx = Context(ws=self.ws)
                 ctx.command = cmd
                 asyncio.create_task(cmd.func(ctx))
             else:
                 print(f"Invalid Command '{name}'", flush=True)
 
-        elif data["type"] == 2: # Event
+        elif data["type"] == 2:  # Event
             event = data.get("event").lower()
             if event in self.events:
                 event_data = data.get("data")
@@ -140,69 +152,83 @@ class Extension:
 
                 asyncio.create_task(coro)
 
-        elif data["type"] == 3: # Eval Response:
+        elif data["type"] == 3:  # Eval Response:
             self.ws.responses[data["uuid"]] = data.get("res", None)
-        else: # Unrecognized 
+        else:  # Unrecognized
             print(data, flush=True)
 
-class Command:
+
+class Command(BaseModel):
     """
     A class that implements the protocol for commands that can be used via the command palette.
     These should not be created manually, instead they should be created via the
     decorator or functional interface.
     """
 
-    def __init__(
-        self,
-        name: str,
-        func: Callable,
-        ext: Extension,
-        title: Optional[str] = None,
-        category: Optional[str] = None,
-        keybind: Optional[str] = None,
-        when: Optional[str] = None,
-    ):
-        """
-        Initialize a command.
-        Args:
-            name: 
-                The internal name of the command.
-            func: 
-                The function to register as a command.
-            ext: 
-                The extension this command is registered in.
-            title: 
-                The title of the command. This is shown in the command palette.
-            category: 
-                The category that this command belongs to.
-            keybind: 
-                The keybind for this command.
-            when: 
-                A condition for when keybinds should be functional.
-        """
+    name: str = Field(..., description="The internal name of the command.")
+    func: Coroutine = Field(..., description="The function to register as a command.")
+    ext: Extension = Field(
+        ..., description="The extension this command is registered in."
+    )
+    title: Optional[str] = Field(
+        description="The title of the command. This is shown in the command palette."
+    )
+    category: Optional[str] = Field(
+        description="The category that this command belongs to."
+    )
+    keybind: Optional[str] = Field(description="The keybind for this command")
+    when: Optional[str] = Field(
+        description="A condition for when keybinds should be functional."
+    )
+    command: Optional[str] = Field(
+        description="The command to execute when triggered. This field is autogenerated."
+    )
+    func_name: Optional[str] = Field(
+        description="The function to execute when triggered. This field is autogenerated."
+    )
 
-        self.name = snake_case_to_camel_case(name)
-        self.title = snake_case_to_title_case(name)
-        self.ext = ext
+    @validator("name")
+    def name_convert(cls, v):
+        return snake_case_to_camel_case(v)
 
-        if not asyncio.iscoroutinefunction(func):
-            raise TypeError("Callback must be a coroutine.")
+    @validator("title")
+    def title_convert(cls, v):
+        return snake_case_to_title_case(v)
 
-        self.func = func
+    @validator("when")
+    def when_convert(cls, v):
+        return python_condition_to_js_condition(v)
+
+    @validator("keybind")
+    def keybind_convert(cls, v):
+        return None if v is None else v.upper()
+
+    @validator("func", pre=True)
+    def func_is_coroutine(cls, v):
+        print(v.__name__)
+        print(type(v))
+        assert asyncio.iscoroutine(v)
+        return v
+
+    class Config:
+        arbitrary_types_allowed = True
+
+    def __init__(self, **data):
+        super().__init__(**data)
+
         self.func_name = self.func.__name__
-        self.category = None if category is False else category
-        self.keybind = keybind.upper() if keybind is not None else None
-        self.when = python_condition_to_js_condition(when)
+        self.command = f"{self.ext.name}.{self.name}"
 
-    def __repr__(self):
-        return f"<vscode.Command {self.name}>"
 
-    @property
-    def extension_string(self) -> str:
-        return f"{self.ext.name}.{self.name}"
+class Configuration(BaseModel):
 
-    def to_dict(self) -> str:
-        cmd = {"command": self.extension_string, "title": self.title}
-        if self.category is not None:
-            cmd.update({"category": self.category})
-        return cmd
+    name: str = "Run Extension"
+    type: str = "extensionHost"
+    request: str = "launch"
+    args: List[str] = ["--extensionDevelopmentPath=${workspaceFolder}"]
+
+
+class Launch(BaseModel):
+
+    version: constr(regex=SEMVER_REGEX) = "0.2.0"
+    configurations: List[Configuration] = [Configuration()]


### PR DESCRIPTION
This PR converts most extension classes into pydantic classes.

The `Extension` class is not converted into a pydantic class because I am investigating a good approach to doing this. Effectively, `Extension.py` contains all information for `package.json`. The ideal approach is to get the json schema for `package.json` and autogenerate the pydantic classes, that way if the schema is updated then it is easy to update the class. However, there is no `package.json` schema that fits vscode extensions exactly. Rather, vscode uses NPMs `package.json` schema and then make modifications within the code rather than creating an actual schema.

What we can do is create an autogenerated `package.json` class, then make `Extension` a subclass and make the necessary changes to conform to vscode.